### PR TITLE
feat: Support for Apollo Federation

### DIFF
--- a/fixtures/directive/c.graphql
+++ b/fixtures/directive/c.graphql
@@ -1,0 +1,3 @@
+type User @key(fields: "id") {
+	id: ID!
+}

--- a/fixtures/directive/c.graphql
+++ b/fixtures/directive/c.graphql
@@ -1,3 +1,6 @@
-type User @key(fields: "id") {
-	id: ID!
+scalar UPC
+
+type Product @key(fields: "upc") {
+  upc: UPC!
+  name: String
 }

--- a/fixtures/directive/e.graphql
+++ b/fixtures/directive/e.graphql
@@ -1,0 +1,8 @@
+scalar UPC
+scalar SKU
+
+type Product @key(fields: "upc") @key(fields: "sku") {
+  upc: UPC!
+  sku: SKU!
+  name: String
+}

--- a/fixtures/directive/f.graphql
+++ b/fixtures/directive/f.graphql
@@ -1,0 +1,8 @@
+type Review @key(fields: "id") {
+  product: Product @provides(fields: "name")
+}
+
+extend type Product @key(fields: "upc") {
+  upc: String @external
+  name: String @external
+}

--- a/fixtures/directive/g.graphql
+++ b/fixtures/directive/g.graphql
@@ -1,0 +1,9 @@
+type Review {
+  id: ID
+}
+
+extend type User @key(fields: "id") {
+  id: ID! @external
+  email: String @external
+  reviews: [Review] @requires(fields: "email")
+}

--- a/fixtures/root-fields/c.graphql
+++ b/fixtures/root-fields/c.graphql
@@ -1,0 +1,8 @@
+extend type Query {
+    me: User
+}
+
+type User @key(fields: "id") {
+    id: ID!
+    name: String
+}

--- a/fixtures/root-fields/d.graphql
+++ b/fixtures/root-fields/d.graphql
@@ -1,0 +1,10 @@
+# import User from './e.graphql'
+
+extend type Query {
+    me: User
+    post: Post
+}
+
+type Post {
+    id: ID!
+}

--- a/fixtures/root-fields/e.graphql
+++ b/fixtures/root-fields/e.graphql
@@ -1,0 +1,4 @@
+type User @key(fields: "id") {
+    id: ID!
+    name: String
+}

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -14,7 +14,7 @@ import {
 
 const builtinTypes = ['String', 'Float', 'Int', 'Boolean', 'ID']
 
-const builtinDirectives = ['deprecated', 'skip','include']
+const builtinDirectives = ['deprecated', 'skip','include', 'key']
 
 export type ValidDefinitionNode =
     | DirectiveDefinitionNode

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -14,7 +14,7 @@ import {
 
 const builtinTypes = ['String', 'Float', 'Int', 'Boolean', 'ID']
 
-const builtinDirectives = ['deprecated', 'skip','include', 'key']
+const builtinDirectives = ['deprecated', 'skip','include', 'key', 'external', 'requires', 'provides']
 
 export type ValidDefinitionNode =
     | DirectiveDefinitionNode

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -310,12 +310,6 @@ type A {
   b: B
 }
 
-type B {
-  hello: String!
-  c1: C1
-  c2: C2
-}
-
 type C1 {
   id: ID!
 }
@@ -323,7 +317,14 @@ type C1 {
 type C2 {
   id: ID!
 }
+
+type B {
+  hello: String!
+  c1: C1
+  c2: C2
+}
 `
+
   t.is(importSchema(schemaA, schemas), expectedSDL)
 })
 
@@ -464,13 +465,22 @@ type A {
   second: String @withB @deprecated
 }
 
-directive @upper on FIELD_DEFINITION
-
 scalar B
+
+directive @upper on FIELD_DEFINITION
 
 directive @withB(argB: B) on FIELD_DEFINITION
 `
   t.is(importSchema('fixtures/directive/a.graphql'), expectedSDL)
+})
+
+test('importSchema: key directive', t => {
+  const expectedSDL = `\
+type User @key(fields: "id") {
+  id: ID!
+}
+`
+  t.is(importSchema('fixtures/directive/c.graphql'), expectedSDL)
 })
 
 test('importSchema: interfaces', t => {
@@ -592,19 +602,19 @@ type A {
   b: B
 }
 
-type B {
-  hello: String!
-  c1: C1
-  c2: C2
-  a: A
-}
-
 type C1 {
   id: ID!
 }
 
 type C2 {
   id: ID!
+}
+
+type B {
+  hello: String!
+  c1: C1
+  c2: C2
+  a: A
 }
 `
   const actualSDL = importSchema('fixtures/circular/a.graphql')
@@ -677,6 +687,41 @@ input PostFilter {
 }
 `
   const actualSDL = importSchema('fixtures/root-fields/a.graphql')
+  t.is(actualSDL, expectedSDL)
+})
+
+test('extend root field', t => {
+  const expectedSDL = `\
+extend type Query {
+  me: User
+}
+
+type User @key(fields: "id") {
+  id: ID!
+  name: String
+}
+`
+  const actualSDL = importSchema('fixtures/root-fields/c.graphql')
+  t.is(actualSDL, expectedSDL)
+})
+
+test('extend root field imports', t => {
+  const expectedSDL = `\
+extend type Query {
+  me: User
+  post: Post
+}
+
+type Post {
+  id: ID!
+}
+
+type User @key(fields: "id") {
+  id: ID!
+  name: String
+}
+`
+  const actualSDL = importSchema('fixtures/root-fields/d.graphql')
   t.is(actualSDL, expectedSDL)
 })
 
@@ -803,6 +848,7 @@ test('import with collision', t => {
 type User {
   id: ID!
   name: String!
+  intro: String
 }
 `
   t.is(importSchema('fixtures/collision/a.graphql'), expectedSDL)

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -476,11 +476,58 @@ directive @withB(argB: B) on FIELD_DEFINITION
 
 test('importSchema: key directive', t => {
   const expectedSDL = `\
-type User @key(fields: "id") {
-  id: ID!
+scalar UPC
+
+type Product @key(fields: "upc") {
+  upc: UPC!
+  name: String
 }
 `
   t.is(importSchema('fixtures/directive/c.graphql'), expectedSDL)
+})
+
+test('importSchema: multiple key directive', t => {
+  const expectedSDL = `\
+scalar UPC
+
+scalar SKU
+
+type Product @key(fields: "upc") @key(fields: "sku") {
+  upc: UPC!
+  sku: SKU!
+  name: String
+}
+`
+  t.is(importSchema('fixtures/directive/e.graphql'), expectedSDL)
+})
+
+test('importSchema: external directive', t => {
+  const expectedSDL = `\
+type Review @key(fields: "id") {
+  product: Product @provides(fields: "name")
+}
+
+extend type Product @key(fields: "upc") {
+  upc: String @external
+  name: String @external
+}
+`
+  t.is(importSchema('fixtures/directive/f.graphql'), expectedSDL)
+})
+
+test('importSchema: requires directive', t => {
+  const expectedSDL = `\
+type Review {
+  id: ID
+}
+
+extend type User @key(fields: "id") {
+  id: ID! @external
+  email: String @external
+  reviews: [Review] @requires(fields: "email")
+}
+`
+  t.is(importSchema('fixtures/directive/g.graphql'), expectedSDL)
 })
 
 test('importSchema: interfaces', t => {


### PR DESCRIPTION
Closing #352

# Description

Add support for Apollo Federation.

1. Added a new `key` directive;
1. Added support for `extend type`;
1. Added 3 tests for checking:
   - `@key` directive
   - `extend type Query`
   - imports

# Examples

## index.js

```javascript
const path = require('path');
const { ApolloServer, gql } = require('apollo-server');
const { buildFederatedSchema } = require('@apollo/federation');

const { importSchema } = require('graphql-import');
const resolvers = require('./graphql/resolvers');

const typeDefs = importSchema(path.join(__dirname, './graphql/schema.graphql'));

const server = new ApolloServer({
  schema: buildFederatedSchema([
    {
      typeDefs: gql(typeDefs),
      resolvers,
    },
  ]),
});

server.listen({ port: 4001 }).then(({ url }) => {
  console.log(`🚀 Server ready at ${url}`);
});
```

## graphql/schema.graphql

```gql
# import Query.* from './user/schema.graphql'
```

## graphql/resolvers.js

```javascript
module.exports = {
  Query: {
    me() {
      return users[0];
    },
  },
  User: {
    __resolveReference(object) {
      return users.find(user => user.id === object.id);
    },
  },
};

const users = [
  {
    id: '1',
    name: 'Ada Lovelace',
    birthDate: '1815-12-10',
    username: '@ada',
  },
  {
    id: '2',
    name: 'Alan Turing',
    birthDate: '1912-06-23',
    username: '@complete',
  },
];
```

## graphql/user/schema.graphql

```gql
# import User from './types.graphql'

extend type Query {
  me: User
}
```

## graphql/user/types.graphql

```gql
type User @key(fields: "id") {
  id: ID!
  name: String
  username: String
}
```
