### PR TITLE
Update grapqhql import match regex 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ const isFile = f => f.endsWith('.graphql')
  */
 export function parseImportLine(importLine: string): RawModule {
   // Apply regex to import line
-  const matches = importLine.match(/^import (\*|(.*)) from ('|")(.*)('|");?$/)
+  const matches = importLine.match(/^import\s+(\*|(.*))\s+from\s+('|")(.*)('|");?$/)
   if (!matches || matches.length !== 6 || !matches[4]) {
     throw new Error(`Too few regex matches: ${matches}`)
   }


### PR DESCRIPTION
Changed grapqhql import match regex to match import with extra spaces 
Before `import Query.*    from    "account/auth/schemla.graphql` this  will throw an error